### PR TITLE
There is no actual dynamic build type, the two types are static and

### DIFF
--- a/rim-build/build.sh
+++ b/rim-build/build.sh
@@ -15,7 +15,7 @@ pushd $SCRIPT_DIR
 
 usage()
 {
-    echo "$0 <install|clean> <static|dynamic>"
+    echo "$0 <install|clean> <static|shared>"
 }
 
 echo_action()
@@ -115,7 +115,7 @@ if [ "$ACTION" != "install" ] && [ "$ACTION" != "clean" ] ; then
 fi
 
 LINK_TYPE=$2
-if [ "$LINK_TYPE" != "static" ] && [ "$LINK_TYPE" != "dynamic" ] ; then
+if [ "$LINK_TYPE" != "static" ] && [ "$LINK_TYPE" != "shared" ] ; then
     usage
     exit
 fi


### PR DESCRIPTION
I'm able to build a static boost library, but not a dynamic boost library, the build fails. It appears that there is no "dynamic" type, the alternative to static is called "shared".
